### PR TITLE
Update JavaConcurrencyAdvancedCommonInterviewQuestions.md

### DIFF
--- a/docs/java/Multithread/JavaConcurrencyAdvancedCommonInterviewQuestions.md
+++ b/docs/java/Multithread/JavaConcurrencyAdvancedCommonInterviewQuestions.md
@@ -73,7 +73,7 @@ public class Singleton {
     private Singleton() {
     }
 
-    public synchronized static Singleton getUniqueInstance() {
+    public  static Singleton getUniqueInstance() {
        //先判断对象是否已经实例过，没有实例化过才进入加锁代码
         if (uniqueInstance == null) {
             //类对象加锁


### PR DESCRIPTION
单例模式实例修改，在单例方法上声明synchronized关键字是不必要的且会造成性能上的开销